### PR TITLE
fix: scrape web data and store in csv file

### DIFF
--- a/hackernews.csv
+++ b/hackernews.csv
@@ -1,0 +1,31 @@
+Title,URL
+We're Charging Our Cars Wrong,https://spectrum.ieee.org/ev-charging-2671242103
+"Mox – modern, secure, all-in-one email server",https://www.xmox.nl/
+Why fastDOOM is fast,https://fabiensanglard.net/fastdoom/index.html
+NetBSD on a JavaStation,https://fatsquirrel.org/oldfartsalmanac/netbsd-on-a-javastation/
+ARC-AGI without pretraining,https://iliao2345.github.io/blog_posts/arc_agi_without_pretraining/arc_agi_without_pretraining.html
+"Writing an LLM from scratch, part 8 – trainable self-attention",https://www.gilesthomas.com/2025/03/llm-from-scratch-8-trainable-self-attention
+Brother accused of locking down third-party printer ink cartridges,https://www.tomshardware.com/peripherals/printers/brother-accused-of-locking-down-third-party-printer-ink-cartridges-via-firmware-updates-removing-older-firmware-versions-from-support-portals
+An small microbial ecosystem has formed on the International Space Station,https://arstechnica.com/science/2025/03/the-space-station-is-nearly-as-microbe-free-as-an-isolation-ward/
+Show HN: Bayleaf – Building a low-profile wireless split keyboard,https://www.graz.io/articles/bayleaf-wireless-keyboard
+The Dead Planet Theory,https://arealsociety.substack.com/p/the-dead-planet-theory
+Translating natural language to first-order logic for logical fallacy detection,https://arxiv.org/abs/2405.02318
+Launch HN: Enhanced Radar (YC W25) – A safety net for air traffic control,item?id=43257323
+Cobalt Networks CobaltOS: Proxmox Port,https://archive.org/details/CobaltOS-Proxmox
+"DARPA exploring growing bio structures of ""unprecedented size"" in microgravity",https://sam.gov/opp/426e5868fcf74dd4ada3768b00b09234/view
+A Map of Python,https://fi-le.net/pypi/
+BMW Group Product Catalog–Historic Models,https://www.bmwgroup-classic.com/en/history/historic-modeloverview-bmw.html
+Satellogic's Open Satellite Feed,https://tech.marksblogg.com/satellogic-open-data-feed.html
+The Demoralization is just Beginning,https://geohot.github.io//blog/jekyll/update/2025/03/03/demoralization-is-just-beginning.html
+Microsoft Publisher will no longer be supported after October 2026,https://support.microsoft.com/en-gb/office/microsoft-publisher-will-no-longer-be-supported-after-october-2026-ee6302a2-4bc7-4841-babf-8e9be3acbfd7
+Should managers still code?,https://theengineeringmanager.substack.com/p/should-managers-still-code
+Show HN: Open-source Deep Research across workplace applications,https://github.com/onyx-dot-app/onyx
+Show HN: Time travel debugging AI for more reliable vibe coding,https://nut.new
+Who's Afraid of Tom Wolfe?,https://commonreader.wustl.edu/c/whos-afraid-of-tom-wolfe/
+Solving SICP,https://lockywolf.wordpress.com/2021/02/08/solving-sicp/
+Tmux – The Essentials (2019),https://davidwinter.dev/2019/03/14/tmux-the-essentials
+"Show HN: Scholium, Your Own Research Assistant",https://github.com/QDScholium/ScholiumAI
+What a crab sees before it gets eaten by a cuttlefish,https://www.nytimes.com/2025/03/03/science/cuttlefish-camouflage-huting-crabs.html
+TurboWarp – Run Scratch projects faster,https://turbowarp.org
+An Uneasy Propaganda Alliance,https://www.historytoday.com/archive/history-matters/uneasy-propaganda-alliance
+The Ancient Art of Color,https://worldhistory.substack.com/p/the-ancient-art-of-color

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/fatih/color"
@@ -18,14 +20,28 @@ func main() {
 
 	defer res.Body.Close()
 
-	doc,err := goquery.NewDocumentFromReader(res.Body)
+	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
 		log.Fatal("Failed to parse HTML:", err)
 	}
 
-	color.Cyan("Latest Hacker New Articles:");
-	doc.Find("tr").Each(func(i int, s *goquery.Selection) {
-         title:= s.Text()
-		 fmt.Printf("%d. %s\n", i+1, title)
+	file, err := os.Create("hackernews.csv")
+	if err != nil {
+		log.Fatal("Failed to create file:", err)
+	}
+
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	writer.Write([]string{"Title", "URL"})
+	color.Cyan("Latest Hacker New Articles:")
+	doc.Find(".titleline > a").Each(func(i int, s *goquery.Selection) {
+		title := s.Text()
+		link, _ := s.Attr("href")
+		writer.Write([]string{title, link})
+		fmt.Printf("%d. %s\n", i+1, title)
 	})
+	color.Green("✅ Data saved to hackernews.csv")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled exporting Hacker News article titles and URLs to a CSV file.
	- Now displays a confirmation message once the data is successfully saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->